### PR TITLE
rofi: increase element-icon border to 4px

### DIFF
--- a/material-ocean.rasi
+++ b/material-ocean.rasi
@@ -89,7 +89,7 @@ element-text, element-icon {
 
 element-icon {
   size: 18px;
-  border: 0px;
+  border: 4px;
 }
 
 element selected {


### PR DESCRIPTION
- Fixes misalignment between icons and text