### PR TITLE
config.rasi: update config to work with new rofi update

### DIFF
--- a/config.rasi
+++ b/config.rasi
@@ -2,6 +2,7 @@ configuration {
   font: "SF Pro Rounded 10";
   show-icons: true;
   hide-scrollbar: true;
-  theme: "~/.config/rofi/material-ocean.rasi";
   kb-cancel: "Escape,Alt+F1";
 }
+
+@theme "~/.config/rofi/material-ocean.rasi"


### PR DESCRIPTION
` theme: "~/.config/rofi/material-ocean.rasi";` is deprecated now and throws error. Updated it to work with new update